### PR TITLE
Create docker-compose.yml

### DIFF
--- a/portainer/docker-compose.yml
+++ b/portainer/docker-compose.yml
@@ -1,0 +1,15 @@
+version: "3"
+services:
+  portainer:
+    image: portainer/portainer-ce
+    container_name: portainer-ce
+    volumes:
+      - /etc/localtime:/etc/localtime:ro
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - /srv/portainer/data:/data
+    ports:
+      - 8000:8000
+      - 9443:9443
+    security_opt:
+      - no-new-privileges:true
+    restart: unless-stopped


### PR DESCRIPTION
Portainer docker-compose.yml file. No need for dummy values in this one as there are no custom values. Working with portainer-ce on Docker Hub, and not using the legacy port 9000